### PR TITLE
Fix the match rule to exclude github urls without projects

### DIFF
--- a/script.user.js
+++ b/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         GitHub Projects Story Points
 // @namespace    pkosiec
-// @version      0.2.0
+// @version      0.2.1
 // @description  Use Story Points in GitHub Project board without a hassle. No labels or issue title modifications needed.
 // @author       Pawel Kosiec
 // @website      https://github.com/pkosiec/gh-projects-story-points/

--- a/script.user.js
+++ b/script.user.js
@@ -5,7 +5,7 @@
 // @description  Use Story Points in GitHub Project board without a hassle. No labels or issue title modifications needed.
 // @author       Pawel Kosiec
 // @website      https://github.com/pkosiec/gh-projects-story-points/
-// @match        https://github.com/*
+// @match        https://github.com/*/projects/*
 // @grant        none
 // @license      MIT
 // @run-at       document-idle


### PR DESCRIPTION
There are still a few more places where it could be run but it shouldn't, for example in `project/new`. It could be solved with using the `@include` rule with regex as mentioned [here](https://violentmonkey.github.io/api/matching/#include--exclude). What do you think about this?